### PR TITLE
fix(core): tui summary should print all tasks, not just cache hits

### DIFF
--- a/packages/nx/src/tasks-runner/life-cycles/tui-summary-life-cycle.ts
+++ b/packages/nx/src/tasks-runner/life-cycles/tui-summary-life-cycle.ts
@@ -54,15 +54,15 @@ export function getTuiTerminalSummaryLifeCycle({
     }
   };
 
-  lifeCycle.printTaskTerminalOutput = (task, taskStatus, terminalOutput) => {
-    tasksToTerminalOutputs[task.id] = { terminalOutput, taskStatus };
-    taskIdsInOrderOfCompletion.push(task.id);
-  };
-
   lifeCycle.endTasks = (taskResults) => {
     for (let t of taskResults) {
       totalCompletedTasks++;
       inProgressTasks.delete(t.task.id);
+      tasksToTerminalOutputs[t.task.id] = {
+        terminalOutput: t.terminalOutput,
+        taskStatus: t.status,
+      };
+      taskIdsInOrderOfCompletion.push(t.task.id);
 
       switch (t.status) {
         case 'remote-cache':


### PR DESCRIPTION
## Current Behavior
For `run-many` successful case only cache hits are being logged

## Expected Behavior
For `run-many` there is an entry for all successful runs.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
